### PR TITLE
Payel Mahapatra-Fix Code Smell Comparison to None should not be constant-Group 4

### DIFF
--- a/homeassistant/components/energy/validate.py
+++ b/homeassistant/components/energy/validate.py
@@ -190,12 +190,12 @@ def _async_validate_usage_stat(
         return
 
     try:
-        current_value: float | None = float(state.state)
-    except ValueError:
+        current_value: float = float(state.state)
+    except (ValueError, TypeError):
         issues.add_issue(hass, "entity_state_non_numeric", entity_id, state.state)
         return
 
-    if current_value is not None and current_value < 0:
+    if current_value < 0:
         issues.add_issue(hass, "entity_negative_state", entity_id, current_value)
 
     device_class = state.attributes.get(ATTR_DEVICE_CLASS)


### PR DESCRIPTION
Payel Mahapatra, Group 4

### Code Smell Issue Prioritized and Motivation 
This pull request aims to fix the code smell "Comparison to None should not be constant". The issue that was prioritised to be fixed is in `_async_validate_usage_stat(...)` of `homeassistant/components/energy/validate.py` at Line Number 198. 

This code smell states that a variable should be checked for None values only at that point in the code when we are certain that a None value may exist. If a None value is not possible, then it only raises confusion when we give a condition to check for its availability. It makes this check redundant or denotes there is a bug that enables the variable to have a None value.

This issue for this type of code smell was prioritised from a total of 33 similar issues because it conformed to our prioritization criteria. Our prioritization criteria stated that any issue that had a long code smell persistence age of 4-6 years needed urgent attention and the files that had a higher cyclomatic complexity and more number of commits were considered vulnerable and in need of refactoring. We also gave code smells that existed in test packages and test files less priority because code from test packages do not reach production. This particular issue that I worked on was observed to have persisted for 4 years which was significantly higher compared to the other issues and the file has a cyclomatic complexity of 60 with the number of commits being 37.

### Chosen Issue and Fix Applied
In this particular issue, it can be seen `current_value` cannot have a value None at that point in code. Just before this check has been put in place, there is a try block that handles exceptions when the value for `current_value` is passed non numeric. So even if a None value was assigned to `current_value` it would have been raised in the try block and an exception would have been thrown. So the check at line 198 becomes redundant.

The easy fix is to remove this condition check. So the condition becomes `current_value < 0:` However, upon trying that, I observed an error during running pre-commit checks from `mypy`. It says `Unsupported operand types for > ("int" and "None")
[operator]`. Image below shows the error. This happens because python wants to keep the check for None in place. This is because during declaration, it is specified `current_value` can have both float and None value. This is not necessary. However, we must remove our code smell and to do that I declared `current_value` to have value type `float`. If a None value appears for it, it will be handled in the try block.

<img width="733" height="514" alt="Image3" src="https://github.com/user-attachments/assets/4fb9591c-0974-48a1-893f-74a571cc527c" />


The issue is thus fixed. Image below shows all the pre-commit checks,  including `mypy` passing. I ran `pytest` for this component and ensured all test cases pass after the issue fix.

<img width="741" height="512" alt="Image2" src="https://github.com/user-attachments/assets/edcb3bf4-7c14-4698-b167-f28cfd9d7585" />
